### PR TITLE
numpad keys update instantly

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -1066,7 +1066,7 @@
     },
 
     widgetKeyup: function(e) {
-      if ((e.keyCode === 65) || (e.keyCode === 77) || (e.keyCode === 80) || (e.keyCode === 46) || (e.keyCode === 8) || (e.keyCode >= 46 && e.keyCode <= 57)) {
+      if ((e.keyCode === 65) || (e.keyCode === 77) || (e.keyCode === 80) || (e.keyCode === 46) || (e.keyCode === 8) || (e.keyCode >= 46 && e.keyCode <= 57) || (e.keyCode >= 96 && e.keyCode <= 105)) {
         this.updateFromWidgetInputs();
       }
     }


### PR DESCRIPTION
When pressing the numbers they update the inputs instantly but when you use the numPad it does not update the input and de-syncs the input from the timePicker

Now numPad is treated the same as the normal keyboard numbers